### PR TITLE
Read and understand schema files

### DIFF
--- a/_gen_edi.json
+++ b/_gen_edi.json
@@ -1,0 +1,738 @@
+{
+  "824": {
+    "Area1": {
+      "ST___0100___Segment": {
+        "143_1": {
+          "value": "",
+          "position": "01"
+        },
+        "329_2": {
+          "value": "",
+          "position": "02"
+        },
+        "1705_3": {
+          "value": "",
+          "position": "03"
+        }
+      },
+      "BGN___0200___Segment": {
+        "353_1": {
+          "value": "",
+          "position": "01"
+        },
+        "127_2": {
+          "value": "",
+          "position": "02"
+        },
+        "373_3": {
+          "value": "",
+          "position": "03"
+        },
+        "337_4": {
+          "value": "",
+          "position": "04"
+        },
+        "623_5": {
+          "value": "",
+          "position": "05"
+        },
+        "127_6": {
+          "value": "",
+          "position": "06"
+        },
+        "640_7": {
+          "value": "",
+          "position": "07"
+        },
+        "306_8": {
+          "value": "",
+          "position": "08"
+        },
+        "786_9": {
+          "value": "",
+          "position": "09"
+        }
+      },
+      "N1___0300___SegmentGroup": [
+        {
+          "N1___0300___Segment": {
+            "98_1": {
+              "value": "",
+              "position": "01"
+            },
+            "93_2": {
+              "value": "",
+              "position": "02"
+            },
+            "66_3": {
+              "value": "",
+              "position": "03"
+            },
+            "67_4": {
+              "value": "",
+              "position": "04"
+            },
+            "706_5": {
+              "value": "",
+              "position": "05"
+            },
+            "98_6": {
+              "value": "",
+              "position": "06"
+            }
+          },
+          "N2___0400___Segment": {
+            "93_1": {
+              "value": "",
+              "position": "01"
+            },
+            "93_2": {
+              "value": "",
+              "position": "02"
+            }
+          },
+          "N3___0500___Segment": {
+            "166_1": {
+              "value": "",
+              "position": "01"
+            },
+            "166_2": {
+              "value": "",
+              "position": "02"
+            }
+          },
+          "N4___0600___Segment": {
+            "19_1": {
+              "value": "",
+              "position": "01"
+            },
+            "156_2": {
+              "value": "",
+              "position": "02"
+            },
+            "116_3": {
+              "value": "",
+              "position": "03"
+            },
+            "26_4": {
+              "value": "",
+              "position": "04"
+            },
+            "309_5": {
+              "value": "",
+              "position": "05"
+            },
+            "310_6": {
+              "value": "",
+              "position": "06"
+            },
+            "1715_7": {
+              "value": "",
+              "position": "07"
+            }
+          },
+          "REF___0700___Segment": {
+            "128_1": {
+              "value": "",
+              "position": "01"
+            },
+            "127_2": {
+              "value": "",
+              "position": "02"
+            },
+            "352_3": {
+              "value": "",
+              "position": "03"
+            },
+            "C040": {
+              "128_1": {
+                "value": "",
+                "position": "01"
+              },
+              "127_2": {
+                "value": "",
+                "position": "02"
+              },
+              "128_3": {
+                "value": "",
+                "position": "03"
+              },
+              "127_4": {
+                "value": "",
+                "position": "04"
+              },
+              "128_5": {
+                "value": "",
+                "position": "05"
+              },
+              "127_6": {
+                "value": "",
+                "position": "06"
+              }
+            }
+          },
+          "PER___0800___Segment": {
+            "366_1": {
+              "value": "",
+              "position": "01"
+            },
+            "93_2": {
+              "value": "",
+              "position": "02"
+            },
+            "365_3": {
+              "value": "",
+              "position": "03"
+            },
+            "364_4": {
+              "value": "",
+              "position": "04"
+            },
+            "365_5": {
+              "value": "",
+              "position": "05"
+            },
+            "364_6": {
+              "value": "",
+              "position": "06"
+            },
+            "365_7": {
+              "value": "",
+              "position": "07"
+            },
+            "364_8": {
+              "value": "",
+              "position": "08"
+            },
+            "443_9": {
+              "value": "",
+              "position": "09"
+            }
+          }
+        }
+      ]
+    },
+    "Area2": {
+      "OTI___0100___SegmentGroup": [
+        {
+          "OTI___0100___Segment": {
+            "110_1": {
+              "value": "",
+              "position": "01"
+            },
+            "128_2": {
+              "value": "",
+              "position": "02"
+            },
+            "127_3": {
+              "value": "",
+              "position": "03"
+            },
+            "142_4": {
+              "value": "",
+              "position": "04"
+            },
+            "124_5": {
+              "value": "",
+              "position": "05"
+            },
+            "373_6": {
+              "value": "",
+              "position": "06"
+            },
+            "337_7": {
+              "value": "",
+              "position": "07"
+            },
+            "28_8": {
+              "value": "",
+              "position": "08"
+            },
+            "329_9": {
+              "value": "",
+              "position": "09"
+            },
+            "143_10": {
+              "value": "",
+              "position": "10"
+            },
+            "480_11": {
+              "value": "",
+              "position": "11"
+            },
+            "353_12": {
+              "value": "",
+              "position": "12"
+            },
+            "640_13": {
+              "value": "",
+              "position": "13"
+            },
+            "346_14": {
+              "value": "",
+              "position": "14"
+            },
+            "306_15": {
+              "value": "",
+              "position": "15"
+            },
+            "305_16": {
+              "value": "",
+              "position": "16"
+            },
+            "641_17": {
+              "value": "",
+              "position": "17"
+            }
+          },
+          "REF___0200___Segment": {
+            "128_1": {
+              "value": "",
+              "position": "01"
+            },
+            "127_2": {
+              "value": "",
+              "position": "02"
+            },
+            "352_3": {
+              "value": "",
+              "position": "03"
+            },
+            "C040": {
+              "128_1": {
+                "value": "",
+                "position": "01"
+              },
+              "127_2": {
+                "value": "",
+                "position": "02"
+              },
+              "128_3": {
+                "value": "",
+                "position": "03"
+              },
+              "127_4": {
+                "value": "",
+                "position": "04"
+              },
+              "128_5": {
+                "value": "",
+                "position": "05"
+              },
+              "127_6": {
+                "value": "",
+                "position": "06"
+              }
+            }
+          },
+          "DTM___0300___Segment": {
+            "374_1": {
+              "value": "",
+              "position": "01"
+            },
+            "373_2": {
+              "value": "",
+              "position": "02"
+            },
+            "337_3": {
+              "value": "",
+              "position": "03"
+            },
+            "623_4": {
+              "value": "",
+              "position": "04"
+            },
+            "1250_5": {
+              "value": "",
+              "position": "05"
+            },
+            "1251_6": {
+              "value": "",
+              "position": "06"
+            }
+          },
+          "PER___0400___Segment": {
+            "366_1": {
+              "value": "",
+              "position": "01"
+            },
+            "93_2": {
+              "value": "",
+              "position": "02"
+            },
+            "365_3": {
+              "value": "",
+              "position": "03"
+            },
+            "364_4": {
+              "value": "",
+              "position": "04"
+            },
+            "365_5": {
+              "value": "",
+              "position": "05"
+            },
+            "364_6": {
+              "value": "",
+              "position": "06"
+            },
+            "365_7": {
+              "value": "",
+              "position": "07"
+            },
+            "364_8": {
+              "value": "",
+              "position": "08"
+            },
+            "443_9": {
+              "value": "",
+              "position": "09"
+            }
+          },
+          "AMT___0500___Segment": {
+            "522_1": {
+              "value": "",
+              "position": "01"
+            },
+            "782_2": {
+              "value": "",
+              "position": "02"
+            },
+            "478_3": {
+              "value": "",
+              "position": "03"
+            }
+          },
+          "QTY___0600___Segment": {
+            "673_1": {
+              "value": "",
+              "position": "01"
+            },
+            "380_2": {
+              "value": "",
+              "position": "02"
+            },
+            "C001": {
+              "355_1": {
+                "value": "",
+                "position": "01"
+              },
+              "1018_2": {
+                "value": "",
+                "position": "02"
+              },
+              "649_3": {
+                "value": "",
+                "position": "03"
+              },
+              "355_4": {
+                "value": "",
+                "position": "04"
+              },
+              "1018_5": {
+                "value": "",
+                "position": "05"
+              },
+              "649_6": {
+                "value": "",
+                "position": "06"
+              },
+              "355_7": {
+                "value": "",
+                "position": "07"
+              },
+              "1018_8": {
+                "value": "",
+                "position": "08"
+              },
+              "649_9": {
+                "value": "",
+                "position": "09"
+              },
+              "355_10": {
+                "value": "",
+                "position": "10"
+              },
+              "1018_11": {
+                "value": "",
+                "position": "11"
+              },
+              "649_12": {
+                "value": "",
+                "position": "12"
+              },
+              "355_13": {
+                "value": "",
+                "position": "13"
+              },
+              "1018_14": {
+                "value": "",
+                "position": "14"
+              },
+              "649_15": {
+                "value": "",
+                "position": "15"
+              }
+            },
+            "61_4": {
+              "value": "",
+              "position": "04"
+            }
+          },
+          "NM1___0650___Segment": {
+            "98_1": {
+              "value": "",
+              "position": "01"
+            },
+            "1065_2": {
+              "value": "",
+              "position": "02"
+            },
+            "1035_3": {
+              "value": "",
+              "position": "03"
+            },
+            "1036_4": {
+              "value": "",
+              "position": "04"
+            },
+            "1037_5": {
+              "value": "",
+              "position": "05"
+            },
+            "1038_6": {
+              "value": "",
+              "position": "06"
+            },
+            "1039_7": {
+              "value": "",
+              "position": "07"
+            },
+            "66_8": {
+              "value": "",
+              "position": "08"
+            },
+            "67_9": {
+              "value": "",
+              "position": "09"
+            },
+            "706_10": {
+              "value": "",
+              "position": "10"
+            },
+            "98_11": {
+              "value": "",
+              "position": "11"
+            },
+            "1035_12": {
+              "value": "",
+              "position": "12"
+            }
+          },
+          "TED___0700___SegmentGroup": [
+            {
+              "TED___0700___Segment": {
+                "647_1": {
+                  "value": "",
+                  "position": "01"
+                },
+                "3_2": {
+                  "value": "",
+                  "position": "02"
+                },
+                "721_3": {
+                  "value": "",
+                  "position": "03"
+                },
+                "719_4": {
+                  "value": "",
+                  "position": "04"
+                },
+                "C030": {
+                  "722_1": {
+                    "value": "",
+                    "position": "01"
+                  },
+                  "1528_2": {
+                    "value": "",
+                    "position": "02"
+                  },
+                  "1686_3": {
+                    "value": "",
+                    "position": "03"
+                  }
+                },
+                "C999": {
+                  "725_1": {
+                    "value": "",
+                    "position": "01"
+                  },
+                  "725_2": {
+                    "value": "",
+                    "position": "02"
+                  }
+                },
+                "724_7": {
+                  "value": "",
+                  "position": "07"
+                },
+                "961_8": {
+                  "value": "",
+                  "position": "08"
+                }
+              },
+              "CTX___0750___Segment": {
+                "C998": {
+                  "9999_1": {
+                    "value": "",
+                    "position": "01"
+                  },
+                  "9998_2": {
+                    "value": "",
+                    "position": "02"
+                  }
+                },
+                "721_2": {
+                  "value": "",
+                  "position": "02"
+                },
+                "719_3": {
+                  "value": "",
+                  "position": "03"
+                },
+                "447_4": {
+                  "value": "",
+                  "position": "04"
+                },
+                "C030": {
+                  "722_1": {
+                    "value": "",
+                    "position": "01"
+                  },
+                  "1528_2": {
+                    "value": "",
+                    "position": "02"
+                  },
+                  "1686_3": {
+                    "value": "",
+                    "position": "03"
+                  }
+                },
+                "C999": {
+                  "725_1": {
+                    "value": "",
+                    "position": "01"
+                  },
+                  "725_2": {
+                    "value": "",
+                    "position": "02"
+                  }
+                }
+              },
+              "NTE___0800___Segment": {
+                "363_1": {
+                  "value": "",
+                  "position": "01"
+                },
+                "352_2": {
+                  "value": "",
+                  "position": "02"
+                }
+              },
+              "RED___0820___Segment": {
+                "352_1": {
+                  "value": "",
+                  "position": "01"
+                },
+                "1609_2": {
+                  "value": "",
+                  "position": "02"
+                },
+                "559_3": {
+                  "value": "",
+                  "position": "03"
+                },
+                "822_4": {
+                  "value": "",
+                  "position": "04"
+                },
+                "1270_5": {
+                  "value": "",
+                  "position": "05"
+                },
+                "1271_6": {
+                  "value": "",
+                  "position": "06"
+                }
+              }
+            }
+          ],
+          "LM___0850___SegmentGroup": [
+            {
+              "LM___0850___Segment": {
+                "559_1": {
+                  "value": "",
+                  "position": "01"
+                },
+                "822_2": {
+                  "value": "",
+                  "position": "02"
+                }
+              },
+              "LQ___0860___SegmentGroup": [
+                {
+                  "LQ___0860___Segment": {
+                    "1270_1": {
+                      "value": "",
+                      "position": "01"
+                    },
+                    "1271_2": {
+                      "value": "",
+                      "position": "02"
+                    }
+                  },
+                  "RED___0870___Segment": {
+                    "352_1": {
+                      "value": "",
+                      "position": "01"
+                    },
+                    "1609_2": {
+                      "value": "",
+                      "position": "02"
+                    },
+                    "559_3": {
+                      "value": "",
+                      "position": "03"
+                    },
+                    "822_4": {
+                      "value": "",
+                      "position": "04"
+                    },
+                    "1270_5": {
+                      "value": "",
+                      "position": "05"
+                    },
+                    "1271_6": {
+                      "value": "",
+                      "position": "06"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "SE___0900___Segment": {
+        "96_1": {
+          "value": "",
+          "position": "01"
+        },
+        "329_2": {
+          "value": "",
+          "position": "02"
+        }
+      }
+    }
+  }
+}

--- a/_gen_xml.json
+++ b/_gen_xml.json
@@ -1,0 +1,303 @@
+{
+  "LIST": {
+    "ControlSegment": {
+      "_BUSINESSID": "",
+      "_BUSINESSQUALIFIER": "",
+      "_CLIENT": "",
+      "_CONTROLTEXT1": "",
+      "_CONTROLTEXT2": "",
+      "_CONTROLTEXT3": "",
+      "_DIRECTION": "",
+      "_DOCUMENTSTATUS": "",
+      "_EDIMESSAGECODE": "",
+      "_EDIMESSAGEFUNCTION": "",
+      "_EDIMESSAGETYPE": "",
+      "_EDITXM": "",
+      "_EDIVERSION": "",
+      "_GSCONTROLNUMBER": "",
+      "_ISACONTROLNUMBER": "",
+      "_PARTNERTYPE": "",
+      "_PAYLOADFIELDNAME": "",
+      "_RECEIVERID": "",
+      "_RECEIVERQUALIFIER": "",
+      "_SECONDARYBUSINESSID": "",
+      "_SECONDARYBUSINESSQUALIFIER": "",
+      "_SENDERID": "",
+      "_SENDERQUALIFIER": "",
+      "_SOURCEDATETIME": "",
+      "_SYSTEMDATETIME": "",
+      "_TABLENAME": "",
+      "_TESTINDICATOR": ""
+    },
+    "ISA": {
+      "_acknowledgmentRequested": "",
+      "_authorizationInformation": "",
+      "_authorizationInformationQualifier": "",
+      "_componentElementSeparator": "",
+      "_interchangeControlNumber": "",
+      "_interchangeControlVersionNumber": "",
+      "_interchangeDate": "",
+      "_interchangeIDQualifier": "",
+      "_interchangeIDQualifier2": "",
+      "_interchangeReceiverID": "",
+      "_interchangeSenderID": "",
+      "_interchangeTime": "",
+      "_interchangeUsageIndicator": "",
+      "_repetitionSeparator": "",
+      "_securityInformation": "",
+      "_securityInformationQualifier": "",
+      "GS__loop": {
+        "_applicationReceiversCode": "",
+        "_applicationSendersCode": "",
+        "_date": "",
+        "_functionalIdentifierCode": "",
+        "_groupControlNumber": "",
+        "_responsibleAgencyCode": "",
+        "_time": "",
+        "_versionReleaseIndustryIdentifierCode": "",
+        "ST__loop": {
+          "_implementationConventionReference": "",
+          "_transactionSetControlNumber": "",
+          "_transactionSetIdentifierCode": "",
+          "BGN": {
+            "_actionCode": "",
+            "_date": "",
+            "_referenceIdentification": "",
+            "_referenceIdentification2": "",
+            "_securityLevelCode": "",
+            "_time": "",
+            "_timeCode": "",
+            "_transactionSetPurposeCode": "",
+            "_transactionTypeCode": ""
+          },
+          "loopN1__loop": {
+            "N1": {
+              "_entityIdentifierCode": "",
+              "_entityIdentifierCode2": "",
+              "_entityRelationshipCode": "",
+              "_identificationCode": "",
+              "_identificationCodeQualifier": "",
+              "_name": "",
+              "N2__loop": {
+                "_name": "",
+                "_name2": ""
+              },
+              "N3__loop": {
+                "_addressInformation": "",
+                "_addressInformation2": ""
+              },
+              "N4": {
+                "_cityName": "",
+                "_countryCode": "",
+                "_countrySubdivisionCode": "",
+                "_locationIdentifier": "",
+                "_locationQualifier": "",
+                "_postalCode": "",
+                "_stateorProvinceCode": ""
+              },
+              "PER__loop": {
+                "_communicationNumber": "",
+                "_communicationNumber2": "",
+                "_communicationNumber3": "",
+                "_communicationNumberQualifier": "",
+                "_communicationNumberQualifier2": "",
+                "_communicationNumberQualifier3": "",
+                "_contactFunctionCode": "",
+                "_contactInquiryReference": "",
+                "_name": ""
+              },
+              "REF__loop": {
+                "_description": "",
+                "_referenceIdentification": "",
+                "_referenceIdentificationQualifier": "",
+                "C040": {
+                  "_referenceIdentification": "",
+                  "_referenceIdentification2": "",
+                  "_referenceIdentification3": "",
+                  "_referenceIdentificationQualifier": "",
+                  "_referenceIdentificationQualifier2": "",
+                  "_referenceIdentificationQualifier3": ""
+                }
+              }
+            }
+          },
+          "loopOTI__loop": {
+            "OTI": {
+              "_actionCode": "",
+              "_applicationAcknowledgmentCode": "",
+              "_applicationReceiversCode": "",
+              "_applicationSendersCode": "",
+              "_applicationType": "",
+              "_date": "",
+              "_groupControlNumber": "",
+              "_referenceIdentification": "",
+              "_referenceIdentificationQualifier": "",
+              "_statusReasonCode": "",
+              "_time": "",
+              "_transactionHandlingCode": "",
+              "_transactionSetControlNumber": "",
+              "_transactionSetIdentifierCode": "",
+              "_transactionSetPurposeCode": "",
+              "_transactionTypeCode": "",
+              "_versionReleaseIndustryIdentifierCode": "",
+              "AMT__loop": {
+                "_amountQualifierCode": "",
+                "_creditDebitFlagCode": "",
+                "_monetaryAmount": ""
+              },
+              "DTM__loop": {
+                "_date": "",
+                "_dateTimePeriod": "",
+                "_dateTimePeriodFormatQualifier": "",
+                "_dateTimeQualifier": "",
+                "_time": "",
+                "_timeCode": ""
+              },
+              "loopLM__loop": {
+                "LM": {
+                  "_agencyQualifierCode": "",
+                  "_sourceSubqualifier": "",
+                  "loopLQ__loop": {
+                    "LQ": {
+                      "_codeListQualifierCode": "",
+                      "_industryCode": "",
+                      "RED__loop": {
+                        "_agencyQualifierCode": "",
+                        "_codeListQualifierCode": "",
+                        "_description": "",
+                        "_industryCode": "",
+                        "_relatedDataIdentificationCode": "",
+                        "_sourceSubqualifier": ""
+                      }
+                    }
+                  }
+                }
+              },
+              "loopTED__loop": {
+                "TED": {
+                  "_applicationErrorConditionCode": "",
+                  "_copyofBadDataElement": "",
+                  "_dataElementNewContent": "",
+                  "_freeformMessage": "",
+                  "_segmentIDCode": "",
+                  "_segmentPositioninTransactionSet": "",
+                  "C030": {
+                    "_componentDataElementPositioninComposite": "",
+                    "_elementPositioninSegment": "",
+                    "_repeatingDataElementPosition": ""
+                  },
+                  "C999": {
+                    "_dataElementReferenceNumber": "",
+                    "_dataElementReferenceNumber2": ""
+                  },
+                  "CTX__loop": {
+                    "_loopIdentifierCode": "",
+                    "_segmentIDCode": "",
+                    "_segmentPositioninTransactionSet": "",
+                    "C030": {
+                      "_componentDataElementPositioninComposite": "",
+                      "_elementPositioninSegment": "",
+                      "_repeatingDataElementPosition": ""
+                    },
+                    "C998__loop": {
+                      "_contextName": "",
+                      "_contextReference": ""
+                    },
+                    "C999": {
+                      "_dataElementReferenceNumber": "",
+                      "_dataElementReferenceNumber2": ""
+                    }
+                  },
+                  "NTE__loop": {
+                    "_description": "",
+                    "_noteReferenceCode": ""
+                  },
+                  "RED__loop": {
+                    "_agencyQualifierCode": "",
+                    "_codeListQualifierCode": "",
+                    "_description": "",
+                    "_industryCode": "",
+                    "_relatedDataIdentificationCode": "",
+                    "_sourceSubqualifier": ""
+                  }
+                }
+              },
+              "NM1__loop": {
+                "_entityIdentifierCode": "",
+                "_entityIdentifierCode2": "",
+                "_entityRelationshipCode": "",
+                "_entityTypeQualifier": "",
+                "_identificationCode": "",
+                "_identificationCodeQualifier": "",
+                "_nameFirst": "",
+                "_nameLastorOrganizationName": "",
+                "_nameLastorOrganizationName2": "",
+                "_nameMiddle": "",
+                "_namePrefix": "",
+                "_nameSuffix": ""
+              },
+              "PER__loop": {
+                "_communicationNumber": "",
+                "_communicationNumber2": "",
+                "_communicationNumber3": "",
+                "_communicationNumberQualifier": "",
+                "_communicationNumberQualifier2": "",
+                "_communicationNumberQualifier3": "",
+                "_contactFunctionCode": "",
+                "_contactInquiryReference": "",
+                "_name": ""
+              },
+              "QTY__loop": {
+                "_freeformInformation": "",
+                "_quantity": "",
+                "_quantityQualifier": "",
+                "C001": {
+                  "_exponent": "",
+                  "_exponent2": "",
+                  "_exponent3": "",
+                  "_exponent4": "",
+                  "_exponent5": "",
+                  "_multiplier": "",
+                  "_multiplier2": "",
+                  "_multiplier3": "",
+                  "_multiplier4": "",
+                  "_multiplier5": "",
+                  "_unitorBasisforMeasurementCode": "",
+                  "_unitorBasisforMeasurementCode2": "",
+                  "_unitorBasisforMeasurementCode3": "",
+                  "_unitorBasisforMeasurementCode4": "",
+                  "_unitorBasisforMeasurementCode5": ""
+                }
+              },
+              "REF__loop": {
+                "_description": "",
+                "_referenceIdentification": "",
+                "_referenceIdentificationQualifier": "",
+                "C040": {
+                  "_referenceIdentification": "",
+                  "_referenceIdentification2": "",
+                  "_referenceIdentification3": "",
+                  "_referenceIdentificationQualifier": "",
+                  "_referenceIdentificationQualifier2": "",
+                  "_referenceIdentificationQualifier3": ""
+                }
+              }
+            }
+          },
+          "SE": {
+            "_numberofIncludedSegments": "",
+            "_transactionSetControlNumber": ""
+          }
+        },
+        "GE": {
+          "_groupControlNumber": "",
+          "_numberofTransactionSetsIncluded": ""
+        }
+      },
+      "IEA": {
+        "_interchangeControlNumber": "",
+        "_numberofIncludedFunctionalGroups": ""
+      }
+    }
+  }
+}

--- a/ptf417_to_json.py
+++ b/ptf417_to_json.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+
+"""
+ptf417_to_json.py
+
+Single-entry Python program to parse a combined schema text file (PTF-417.TXT)
+that contains both EDI schema (X12 824) and XML schema DSL blocks, and generate
+edi.json and xml.json matching the existing structure in this workspace.
+
+If the PTF file is not available, the script can fall back to reading
+`ediSchema.txt` and `xmlSchema.txt` directly.
+
+Usage examples:
+  - Default (auto-detect inputs, write to edi.json and xml.json):
+      python ptf417_to_json.py
+
+  - Explicit paths:
+      python ptf417_to_json.py \
+        --ptf /path/to/PTF-417.TXT \
+        --edi-schema /workspace/ediSchema.txt \
+        --xml-schema /workspace/xmlSchema.txt \
+        --out-edi /workspace/edi.json \
+        --out-xml /workspace/xml.json
+
+Notes:
+  - The EDI parser extracts the message 824 layout (areas, segment groups,
+    segments, elements, composites) and renders a JSON skeleton with element
+    positions and empty values, mirroring the current `edi.json`.
+  - The XML parser reads the DSL-style schema (def Type {...}) and renders a
+    single-instance skeleton tree where repeated constructs ([]) are represented
+    as a single object with a `__loop` suffix, mirroring the current `xml.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple, Any
+
+################################################################################
+# Utilities
+################################################################################
+
+def read_text_file(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def write_json_file(path: str, data: Any) -> None:
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+################################################################################
+# EDI schema parsing (from Extol-style DSL as seen in ediSchema.txt)
+################################################################################
+
+@dataclass
+class EdiElement:
+    position: int
+    # Simple element: element_id is numeric string; Composite: composite_name
+    element_id: Optional[str] = None
+    composite_name: Optional[str] = None
+
+
+@dataclass
+class EdiSegmentDef:
+    name: str
+    elements: List[EdiElement] = field(default_factory=list)
+
+
+@dataclass
+class EdiCompositeDef:
+    name: str
+    elements: List[Tuple[int, str]] = field(default_factory=list)  # (position, simple_id)
+
+
+@dataclass
+class EdiAreaEntry:
+    line_num: str  # like '0100'
+    kind: str      # 'segment' or 'segmentGroup'
+    name: str
+    cardinality: str
+    children: List['EdiAreaEntry'] = field(default_factory=list)
+
+
+class EdiSchemaParser:
+    def __init__(self, edi_text: str) -> None:
+        self.text = edi_text
+        self.segment_defs: Dict[str, EdiSegmentDef] = {}
+        self.composite_defs: Dict[str, EdiCompositeDef] = {}
+        self.message_824_areas: Dict[str, List[EdiAreaEntry]] = {}
+
+    def parse(self) -> None:
+        self._parse_composites()
+        self._parse_segments()
+        self._parse_message_824()
+
+    # --- Low-level helpers ---
+
+    @staticmethod
+    def _strip_comments(s: str) -> str:
+        # Remove /* ... */ comments
+        s = re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
+        return s
+
+    def _find_blocks(self, pattern: str) -> List[Tuple[str, int, int]]:
+        # Return list of (name, start_idx, end_idx) for blocks like: def segment NAME { ... }
+        blocks: List[Tuple[str, int, int]] = []
+        for m in re.finditer(pattern, self.text):
+            name = m.group(1)
+            start = m.end()
+            end = self._find_matching_brace(start)
+            if end != -1:
+                blocks.append((name, start, end))
+        return blocks
+
+    def _find_matching_brace(self, start_idx: int) -> int:
+        return self._find_matching_brace_in_text(self.text, start_idx)
+
+    def _find_matching_brace_in_text(self, text: str, start_idx: int) -> int:
+        depth = 0
+        i = start_idx
+        while i < len(text):
+            ch = text[i]
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                if depth == 0:
+                    return i
+                depth -= 1
+            i += 1
+        return -1
+
+    # --- Parse composite element definitions ---
+
+    def _parse_composites(self) -> None:
+        pattern = r"def\s+compositeElement\s+(\w+)\s*\{"
+        for name, start, end in self._find_blocks(pattern):
+            body = self.text[start:end]
+            comp = EdiCompositeDef(name=name)
+            for line in body.splitlines():
+                line = line.strip()
+                m = re.match(r"^(\d{1,2})\s+simpleElement\s+(\d+)\b", line)
+                if m:
+                    pos = int(m.group(1))
+                    simple_id = m.group(2)
+                    comp.elements.append((pos, simple_id))
+            # Sort by position to ensure stable ordering
+            comp.elements.sort(key=lambda t: t[0])
+            self.composite_defs[name] = comp
+
+    # --- Parse segment definitions ---
+
+    def _parse_segments(self) -> None:
+        pattern = r"def\s+segment\s+(\w+)\s*\{"
+        for name, start, end in self._find_blocks(pattern):
+            body = self.text[start:end]
+            seg = EdiSegmentDef(name=name)
+            for line in body.splitlines():
+                line = line.strip()
+                # 01 simpleElement 143 [1..1]
+                m1 = re.match(r"^(\d{1,2})\s+simpleElement\s+(\d+)\b", line)
+                if m1:
+                    pos = int(m1.group(1))
+                    element_id = m1.group(2)
+                    seg.elements.append(EdiElement(position=pos, element_id=element_id))
+                    continue
+                # 04 compositeElement C040 [0..1]
+                m2 = re.match(r"^(\d{1,2})\s+compositeElement\s+([A-Za-z0-9]+)\b", line)
+                if m2:
+                    pos = int(m2.group(1))
+                    comp_name = m2.group(2)
+                    seg.elements.append(EdiElement(position=pos, composite_name=comp_name))
+                    continue
+            seg.elements.sort(key=lambda e: e.position)
+            self.segment_defs[name] = seg
+
+    # --- Parse the message 824 area structure ---
+
+    def _parse_message_824(self) -> None:
+        # Locate the message 824 block inside `def derivedMessage ... { def message 824 { ... } }`
+        # We find all def message <num> blocks and pick the one named 824.
+        msg_pattern = r"def\s+message\s+824\s*\{"
+        m = re.search(msg_pattern, self.text)
+        if not m:
+            return
+        start = m.end()
+        end = self._find_matching_brace(start)
+        if end == -1:
+            return
+        body = self.text[start:end]
+
+        # Parse areas: def area 1 { ... }, def area 2 { ... }
+        area_pattern = r"def\s+area\s+(\d+)\s*\{"
+        areas: Dict[str, List[EdiAreaEntry]] = {}
+        for am in re.finditer(area_pattern, body):
+            area_num = am.group(1)
+            astart_rel = am.end()
+            aend_rel = self._find_matching_brace_in_text(body, astart_rel)
+            if aend_rel == -1:
+                continue
+            abody = body[astart_rel:aend_rel]
+            entries = self._parse_area_entries(abody)
+            areas[area_num] = entries
+        self.message_824_areas = areas
+
+    def _parse_area_entries(self, abody: str) -> List[EdiAreaEntry]:
+        entries: List[EdiAreaEntry] = []
+        # Strip nested def segmentGroup blocks from this level so their internal
+        # 4-digit listing lines don't get treated as top-level entries here.
+        header = self._strip_segment_group_defs(abody)
+        lines = [ln.strip() for ln in header.splitlines() if ln.strip()]
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            # e.g. 0100 segment ST [1..1]
+            m_seg = re.match(r"^(\d{4})\s+segment\s+(\w+)\s*(\[[^\]]*\])?", line)
+            if m_seg:
+                entries.append(EdiAreaEntry(
+                    line_num=m_seg.group(1),
+                    kind='segment',
+                    name=m_seg.group(2),
+                    cardinality=m_seg.group(3) or ''
+                ))
+                i += 1
+                continue
+
+            # e.g. 0300 segmentGroup N1 []  followed by def segmentGroup N1 { ... }
+            m_sg = re.match(r"^(\d{4})\s+segmentGroup\s+(\w+)\s*(\[[^\]]*\])?", line)
+            if m_sg:
+                line_num = m_sg.group(1)
+                name = m_sg.group(2)
+                card = m_sg.group(3) or ''
+                # Find the group's definition block within the full abody
+                sub_m = re.search(rf"def\s+segmentGroup\s+{re.escape(name)}\s*\{{", abody)
+                if sub_m:
+                    sub_start = sub_m.end()
+                    sub_end = self._find_matching_brace_in_text(abody, sub_start)
+                    if sub_end != -1:
+                        sub_body = abody[sub_start:sub_end]
+                        children = self._parse_area_entries(sub_body)
+                        entries.append(EdiAreaEntry(
+                            line_num=line_num,
+                            kind='segmentGroup',
+                            name=name,
+                            cardinality=card,
+                            children=children
+                        ))
+                        i += 1
+                        continue
+                # If we cannot find the formal def block, still record as empty group
+                entries.append(EdiAreaEntry(
+                    line_num=line_num,
+                    kind='segmentGroup',
+                    name=name,
+                    cardinality=card,
+                    children=[]
+                ))
+                i += 1
+                continue
+            i += 1
+        return entries
+
+    def _strip_segment_group_defs(self, text: str) -> str:
+        # Remove all occurrences of: def segmentGroup NAME { ... }
+        out = []
+        i = 0
+        while i < len(text):
+            m = re.search(r"def\s+segmentGroup\s+\w+\s*\{", text[i:])
+            if not m:
+                out.append(text[i:])
+                break
+            start = i + m.start()
+            # append up to start
+            out.append(text[i:start])
+            block_start = i + m.end()
+            block_end = self._find_matching_brace_in_text(text, block_start)
+            if block_end == -1:
+                # malformed; stop removal
+                out.append(text[block_start:])
+                break
+            # skip the entire block including trailing '}'
+            i = block_end + 1
+        return ''.join(out)
+
+    # --- Render to JSON matching existing edi.json structure ---
+
+    def render_edi_json(self) -> Dict[str, Any]:
+        # Only message 824 is needed
+        result: Dict[str, Any] = {"824": {}}
+        # Area 1 and Area 2
+        for area_num, entries in sorted(self.message_824_areas.items(), key=lambda t: int(t[0])):
+            area_key = f"Area{area_num}"
+            result["824"][area_key] = self._render_area(entries)
+        return result
+
+    def _render_area(self, entries: List[EdiAreaEntry]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for entry in entries:
+            if entry.kind == 'segment':
+                seg_key = f"{entry.name}___{entry.line_num}___Segment"
+                out[seg_key] = self._render_segment(entry.name)
+            elif entry.kind == 'segmentGroup':
+                grp_key = f"{entry.name}___{entry.line_num}___SegmentGroup"
+                # As per existing edi.json, groups are arrays with a single object sample
+                grp_obj: Dict[str, Any] = self._render_group(entry)
+                out[grp_key] = [grp_obj]
+        return out
+
+    def _render_group(self, group: EdiAreaEntry) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for child in group.children:
+            if child.kind == 'segment':
+                seg_key = f"{child.name}___{child.line_num}___Segment"
+                out[seg_key] = self._render_segment(child.name)
+            elif child.kind == 'segmentGroup':
+                grp_key = f"{child.name}___{child.line_num}___SegmentGroup"
+                out[grp_key] = [self._render_group(child)]
+        return out
+
+    def _render_segment(self, seg_name: str) -> Dict[str, Any]:
+        seg = self.segment_defs.get(seg_name)
+        if not seg:
+            return {}
+        out: Dict[str, Any] = {}
+        for elem in seg.elements:
+            if elem.element_id is not None:
+                key = f"{elem.element_id}_{elem.position}"
+                out[key] = {"value": "", "position": f"{elem.position:02d}"}
+            elif elem.composite_name is not None:
+                comp = self.composite_defs.get(elem.composite_name)
+                comp_key = elem.composite_name
+                comp_obj: Dict[str, Any] = {}
+                if comp:
+                    for cpos, simple_id in sorted(comp.elements, key=lambda t: t[0]):
+                        ckey = f"{simple_id}_{cpos}"
+                        comp_obj[ckey] = {"value": "", "position": f"{cpos:02d}"}
+                out[comp_key] = comp_obj
+        return out
+
+
+################################################################################
+# XML schema parsing (from JS/DSL string as seen in xmlSchema.txt)
+################################################################################
+
+@dataclass
+class XmlField:
+    name: str
+    type_name: Optional[str]  # None for String
+    is_list: bool
+
+
+@dataclass
+class XmlType:
+    name: str
+    fields: List[XmlField] = field(default_factory=list)
+
+
+class XmlSchemaParser:
+    def __init__(self, xml_text: str) -> None:
+        self.text = xml_text
+        self.types: Dict[str, XmlType] = {}
+
+    def parse(self) -> None:
+        # If it's the JS wrapper with export const schemaInput = `...` extract the inner DSL
+        dsl = self._extract_dsl(self.text)
+        self._parse_types(dsl)
+
+    def _extract_dsl(self, text: str) -> str:
+        m = re.search(r"schemaInput\s*=\s*`([\s\S]*?)`;\s*$", text, re.MULTILINE)
+        if m:
+            return m.group(1)
+        return text
+
+    def _parse_types(self, dsl: str) -> None:
+        # Find all def TypeName { ... }
+        for m in re.finditer(r"def\s+(\w+)\s*\{", dsl):
+            type_name = m.group(1)
+            start = m.end()
+            end = self._find_matching_brace(dsl, start)
+            if end == -1:
+                continue
+            body = dsl[start:end]
+            xml_type = XmlType(name=type_name)
+            for line in body.splitlines():
+                line = line.strip()
+                if not line or line.startswith('//'):
+                    continue
+                # Match attribute field:  _FIELD String ( ... ) ;
+                if re.match(r"^[A-Za-z0-9_]+\s+String\b", line):
+                    field_name = line.split()[0]
+                    xml_type.fields.append(XmlField(name=field_name, type_name=None, is_list=False))
+                    continue
+                # Match nested type field:  Child Type ;  or  Child Type [] ;
+                m2 = re.match(r"^([A-Za-z0-9_]+)\s+([A-Za-z0-9_$]+)\s*(\[\])?\s*;", line)
+                if m2:
+                    field_name = m2.group(1)
+                    ref_type = m2.group(2)
+                    is_list = m2.group(3) is not None
+                    xml_type.fields.append(XmlField(name=field_name, type_name=ref_type, is_list=is_list))
+                    continue
+            self.types[type_name] = xml_type
+
+    def _find_matching_brace(self, text: str, start_idx: int) -> int:
+        depth = 0
+        i = start_idx
+        while i < len(text):
+            ch = text[i]
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                if depth == 0:
+                    return i
+                depth -= 1
+            i += 1
+        return -1
+
+    # --- Render to JSON matching existing xml.json structure ---
+
+    def render_xml_json(self) -> Dict[str, Any]:
+        # Root type is LIST
+        if 'LIST' not in self.types:
+            return {}
+        root = self._instantiate_type('LIST')
+        return { 'LIST': root }
+
+    def _instantiate_type(self, type_name: str) -> Dict[str, Any]:
+        t = self.types.get(type_name)
+        if not t:
+            return {}
+        obj: Dict[str, Any] = {}
+        for field in t.fields:
+            if field.type_name is None:
+                # Attribute (String)
+                obj[field.name] = ""
+            else:
+                # Nested type
+                nested = self._instantiate_nested(field.type_name)
+                if field.is_list:
+                    # Use __loop key and represent a single object (not an array), matching xml.json
+                    obj[f"{field.name}__loop"] = nested
+                else:
+                    obj[field.name] = nested
+        return obj
+
+    def _instantiate_nested(self, type_name: str) -> Any:
+        # Some schema uses type names with namespaces like Stglogistics824JSON$GS
+        # The type definition is referenced without the namespace prefix in the DSL.
+        base_name = type_name.split('$')[-1]
+        nested_obj = self._instantiate_type(base_name)
+        return nested_obj
+
+
+################################################################################
+# Combined parser/orchestrator
+################################################################################
+
+class PtfOrchestrator:
+    def __init__(self, ptf_path: Optional[str], edi_schema_path: Optional[str], xml_schema_path: Optional[str]) -> None:
+        self.ptf_path = ptf_path
+        self.edi_schema_path = edi_schema_path
+        self.xml_schema_path = xml_schema_path
+
+    def load_sources(self) -> Tuple[str, str]:
+        # If PTF exists, split into EDI and XML regions by simple heuristics; else use separate files
+        if self.ptf_path and os.path.exists(self.ptf_path):
+            ptf = read_text_file(self.ptf_path)
+            # Heuristic split: EDI DSL contains 'def derivedMessage' and 'def segment',
+            # XML DSL section contained within backticks following 'schemaInput'
+            # Extract XML DSL block if present
+            xml_part = ''
+            mxml = re.search(r"schemaInput\s*=\s*`([\s\S]*?)`;", ptf)
+            if mxml:
+                xml_part = mxml.group(1)
+            # Remove XML part from EDI text to avoid confusing the EDI parser
+            edi_part = ptf
+            if xml_part:
+                edi_part = ptf.replace(xml_part, '')
+            return edi_part, xml_part
+        # Fallback
+        if not self.edi_schema_path or not os.path.exists(self.edi_schema_path):
+            raise FileNotFoundError("EDI schema source not found. Provide --ptf or --edi-schema.")
+        if not self.xml_schema_path or not os.path.exists(self.xml_schema_path):
+            raise FileNotFoundError("XML schema source not found. Provide --ptf or --xml-schema.")
+        return read_text_file(self.edi_schema_path), read_text_file(self.xml_schema_path)
+
+
+################################################################################
+# Main
+################################################################################
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Parse PTF-417.TXT or separate schemas to generate edi.json and xml.json")
+    parser.add_argument('--ptf', dest='ptf', default=None, help='Path to combined PTF-417.TXT containing both EDI and XML schema')
+    parser.add_argument('--edi-schema', dest='edi_schema', default='/workspace/ediSchema.txt', help='Path to EDI schema DSL file (fallback)')
+    parser.add_argument('--xml-schema', dest='xml_schema', default='/workspace/xmlSchema.txt', help='Path to XML schema DSL file (fallback)')
+    parser.add_argument('--out-edi', dest='out_edi', default='/workspace/edi.json', help='Output path for EDI JSON')
+    parser.add_argument('--out-xml', dest='out_xml', default='/workspace/xml.json', help='Output path for XML JSON')
+
+    args = parser.parse_args(argv)
+
+    orchestrator = PtfOrchestrator(args.ptf, args.edi_schema, args.xml_schema)
+    edi_text, xml_text = orchestrator.load_sources()
+
+    # EDI parse and render
+    edi_parser = EdiSchemaParser(edi_text)
+    edi_parser.parse()
+    edi_json = edi_parser.render_edi_json()
+
+    # XML parse and render
+    xml_parser = XmlSchemaParser(xml_text)
+    xml_parser.parse()
+    xml_json = xml_parser.render_xml_json()
+
+    # Write outputs
+    write_json_file(args.out_edi, edi_json)
+    write_json_file(args.out_xml, xml_json)
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Adds `ptf417_to_json.py` to generate `edi.json` and `xml.json` from a combined schema file or individual schema files.

---
<a href="https://cursor.com/background-agent?bcId=bc-97340fe8-2bfe-411d-83e5-0d79b370b46e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97340fe8-2bfe-411d-83e5-0d79b370b46e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

